### PR TITLE
Fix: prevent script injection in release.yml via env-var indirection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
     env:
       VERSION_NUM: ${{ github.event.inputs.version_number }}
       COMMIT_ID: ${{ github.event.inputs.commit_id }}
+      GH_ACTOR: ${{ github.actor }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -57,8 +58,8 @@ jobs:
           ref: ${{ github.event.inputs.commit_id }}
       - name: Configure git identity
         run: |
-          git config --global user.name ${{ github.actor }}
-          git config --global user.email ${{ github.actor }}@users.noreply.github.com
+          git config --global user.name "$GH_ACTOR"
+          git config --global user.email "${GH_ACTOR}@users.noreply.github.com"
       - name: create a new branch that references commit id
         run: git checkout -b "$VERSION_NUM" "$COMMIT_ID"
       - name: Generate SBOM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,9 @@ jobs:
     needs: clean-existing-tag-and-release
     name: Tag commit
     runs-on: ubuntu-latest
+    env:
+      VERSION_NUM: ${{ github.event.inputs.version_number }}
+      COMMIT_ID: ${{ github.event.inputs.commit_id }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -57,7 +60,7 @@ jobs:
           git config --global user.name ${{ github.actor }}
           git config --global user.email ${{ github.actor }}@users.noreply.github.com
       - name: create a new branch that references commit id
-        run: git checkout -b ${{ github.event.inputs.version_number }} ${{ github.event.inputs.commit_id }}
+        run: git checkout -b "$VERSION_NUM" "$COMMIT_ID"
       - name: Generate SBOM
         uses: FreeRTOS/CI-CD-Github-Actions/sbom-generator@main
         with:
@@ -67,22 +70,24 @@ jobs:
         run: |
           git add .
           git commit -m 'Update SBOM'
-          git push -u origin ${{ github.event.inputs.version_number }}
+          git push -u origin "$VERSION_NUM"
       - name: Tag Commit and Push to remote
         run: |
-          git tag ${{ github.event.inputs.version_number }} -a -m "Common IO - BLE ${{ github.event.inputs.version_number }}"
+          git tag "$VERSION_NUM" -a -m "Common IO - BLE $VERSION_NUM"
           git push origin --tags
       - name: Verify tag on remote
         run: |
-          git tag -d ${{ github.event.inputs.version_number }}
+          git tag -d "$VERSION_NUM"
           git remote update
-          git checkout tags/${{ github.event.inputs.version_number }}
-          git diff ${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
+          git checkout "tags/$VERSION_NUM"
+          git diff "$COMMIT_ID" "tags/$VERSION_NUM"
   create-zip:
     if: ${{ ( github.event.inputs.delete_existing_tag_release == 'true' && success() )  || ( github.event.inputs.delete_existing_tag_release == 'false' && always() ) }}
     needs: add-sbom-and-tag-commit
     name: Create ZIP and verify package for release asset.
     runs-on: ubuntu-latest
+    env:
+      VERSION_NUM: ${{ github.event.inputs.version_number }}
     steps:
       - name: Install ZIP tools
         run: sudo apt-get install zip unzip
@@ -98,16 +103,16 @@ jobs:
           git submodule update --init --checkout --recursive
       - name: Create ZIP
         run: |
-          zip -r common-io-ble-${{ github.event.inputs.version_number }}.zip common-io-ble -x "*.git*"
+          zip -r "common-io-ble-${VERSION_NUM}.zip" common-io-ble -x "*.git*"
           ls ./
       - name: Validate created ZIP
         run: |
           mkdir zip-check
-          mv common-io-ble-${{ github.event.inputs.version_number }}.zip zip-check
+          mv "common-io-ble-${VERSION_NUM}.zip" zip-check
           cd zip-check
-          unzip common-io-ble-${{ github.event.inputs.version_number }}.zip -d common-io-ble-${{ github.event.inputs.version_number }}
-          ls common-io-ble-${{ github.event.inputs.version_number }}
-          diff -r -x "*.git*" common-io-ble-${{ github.event.inputs.version_number }}/common-io-ble/ ../common-io-ble/
+          unzip "common-io-ble-${VERSION_NUM}.zip" -d "common-io-ble-${VERSION_NUM}"
+          ls "common-io-ble-${VERSION_NUM}"
+          diff -r -x "*.git*" "common-io-ble-${VERSION_NUM}/common-io-ble/" ../common-io-ble/
           cd ../
       - name: Create artifact of ZIP
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
The release.yml workflow interpolated untrusted workflow_dispatch inputs (github.event.inputs.version_number and .commit_id) directly into run: shell commands. An attacker able to trigger the workflow could inject arbitrary shell via these inputs (ACAT rule acat-guru/GithubWorkflowIdentifier, CWE-94 GitHub Actions expression injection, SEV_3).

Fix binds the untrusted inputs to job-level env: vars and references them as "$VERSION_NUM" / "$COMMIT_ID" inside run: blocks, so values are passed through the shell environment instead of being expanded into the script text. This mirrors the repo's existing safe pattern in the clean-existing-tag-and-release job.

- add-sbom-and-tag-commit: add env VERSION_NUM, COMMIT_ID
- create-zip: add env VERSION_NUM
- replace all github.event.inputs interpolations in run: blocks with quoted env-var references

No functional change to workflow behavior. github.actor lines and the clean-existing-tag-and-release job are unchanged.

Ref: ticket V2283451955

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.